### PR TITLE
requirements: Freeze `motor` at `3.0.0`

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ gitpython
 hachoir
 heroku3
 lyricsgenius
-motor
+motor==3.0.0
 pillow
 psutil
 py-tgcalls==0.8.6


### PR DESCRIPTION
In latest version `3.1.1` of `motor` users have to face `AttributeError`.

**Error:** `AttributeError: type object 'ClientEncryption' has no attribute 'rewrap_many_data_key'`