### PR TITLE
Bump py-tgcalls to 0.9.7

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ lyricsgenius
 motor==3.0.0
 pillow
 psutil
-py-tgcalls==0.8.6
+py-tgcalls==0.9.7
 pykeyboard
 pyrogram==1.4.16
 python-dotenv


### PR DESCRIPTION
I checked this version of py-tgcalls and verified that this version is ok with the yukkimusic so sending pull for bumping it from 0.8.6 to 0.9.7